### PR TITLE
Support UnsafeAccessorKind.Constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Generated code is fully typed, you can access private filed via IntelliSense and
 * Supports `readonly` field and property
 * Supports `ref` return
 * Supports mutable struct
+* Supports instance constructor
 
-For example, this is the mutable struct and static, ref return sample.
+For example, this is the mutable struct and static, ref return, and constructor sample.
 
 ```csharp
 using PrivateProxy;
@@ -73,6 +74,9 @@ public struct MutableStructSample
 
     // static and ref sample
     static ref int GetInstanceCounter(ref MutableStructSample sample) => ref sample._counter;
+    
+    // constructor sample
+    MutalbeStructSample(int x, int y) { /* ... */ }
 }
 
 // use ref partial struct
@@ -93,6 +97,9 @@ ref var counter = ref MutableStructSampleProxy.GetInstanceCounter(ref sample);
 Console.WriteLine(counter); // 3
 counter = 9999;
 Console.WriteLine(proxy._counter); // 9999
+
+// call private constructor and create instance.
+var sample = MutableStructSampleProxy.CreateMutableStructFromConstructor(111, 222);
 ```
 
 Installation
@@ -124,7 +131,7 @@ public class/* struct */ SupportTarget
     private ref readonly int RefReadOnlyGetOnlyProperty => ref field;
 
     // method
-    private void VoidMethod() => { }
+    private void VoidMethod() { }
     private int ReturnMethod() => field;
     private int ParameterMethod(int x, int y) => x + y;
     private void RefOutInMethod(in int x, ref int y, out int z, ref readonly int xyz) { z = field; }
@@ -148,6 +155,10 @@ public class/* struct */ SupportTarget
     static ref int StaticRefReturnMethod() => ref staticField;
     static ref readonly int StaticRefReadOnlyReturnMethod() => ref staticField;
     static ref int StaticRefReturnMethodParameter() => ref staticField;
+    
+    // constructor
+    SupportTarget() { }
+    SupportTarget(int x, int y) { }
 }
 ```
 
@@ -181,12 +192,13 @@ public GeneratePrivateProxyAttribute(Type target, PrivateProxyGenerateKinds gene
 [Flags]
 internal enum PrivateProxyGenerateKinds
 {
-    All = 0, // Field | Method | Property | Instance | Static
+    All = 0, // Field | Method | Property | Instance | Static | Constructor
     Field = 1,
     Method = 2,
     Property = 4,
     Instance = 8,
     Static = 16,
+    Constructor = 32,
 }
 ```
 

--- a/sandbox/ClassLibrary/Class1.cs
+++ b/sandbox/ClassLibrary/Class1.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS8321
 #pragma warning disable CS0414
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.Marshalling;
 
 namespace ClassLibrary
@@ -12,6 +13,10 @@ namespace ClassLibrary
         private NestedPrivate _nesterPrivate = new NestedPrivate();
         private NestedPublic _nesterPublic = new NestedPublic();
         private InternalEnum _internalEnum = default;
+
+        MyClass()
+        {
+        }
 
         private void PrivateMethod()
         {

--- a/sandbox/ConsoleAppNet8/BlogSample.cs
+++ b/sandbox/ConsoleAppNet8/BlogSample.cs
@@ -13,8 +13,6 @@ using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
 
-
-
 public class Sample
 {
     int _field1;

--- a/sandbox/ConsoleAppNet8/BlogSample.cs
+++ b/sandbox/ConsoleAppNet8/BlogSample.cs
@@ -21,8 +21,17 @@ public class Sample
     int _field2;
     public int PrivateProperty { get; private set; }
     int PrivateAdd(int x, int y) => x + y;
-}
 
+    Sample()
+    {
+    }
+
+    Sample(int x, int y)
+    {
+        _field1 = x;
+        _field2 = y;
+    }
+}
 
 [GeneratePrivateProxy(typeof(Sample))]
 public partial struct SampleProxy;

--- a/src/PrivateProxy.Generator/MetaMember.cs
+++ b/src/PrivateProxy.Generator/MetaMember.cs
@@ -5,7 +5,7 @@ namespace PrivateProxy.Generator;
 
 public enum MemberKind
 {
-    Field, Property, Method
+    Field, Property, Method, Constructor
 }
 
 public class MetaMember
@@ -82,11 +82,10 @@ public class MetaMember
             // ref readonly int Method3() => ref refField;
             // readonly ref int Method4() => ref refField;
             // readonly ref readonly int Method5() => ref refField;
-
-
+            
             this.MemberType = m.ReturnType;
             this.MethodParameters = m.Parameters;
-            this.MemberKind = MemberKind.Method;
+            this.MemberKind = m.Name == ".ctor" ? MemberKind.Constructor : MemberKind.Method;
 
             (this.IsRefReturn, this.IsRequireReadOnly) = (m.ReturnsByRef, m.ReturnsByRefReadonly) switch
             {

--- a/src/PrivateProxy.Generator/PrivateProxyGenerator.cs
+++ b/src/PrivateProxy.Generator/PrivateProxyGenerator.cs
@@ -137,7 +137,7 @@ namespace PrivateProxy
         // If only set Static or Instance, generate all member kind
         if (!generateField && !generateProperty && !generateMethod && !generateConstructor)
         {
-            generateField = generateProperty = generateMethod = generateConstructor = true;
+            generateField = generateProperty = generateMethod = true;
         }
         // If only set member kind, generate both static and instance
         if (!generateStatic && !generateInstance)
@@ -196,10 +196,15 @@ namespace PrivateProxy
 
                 if (m.DeclaredAccessibility == Accessibility.Public) continue;
 
-                if ((m.Name == ".ctor" && generateConstructor) || generateMethod)
+                if (m.Name == ".ctor")
                 {
-                    list.Add(new(item));
+                    if (!generateConstructor) continue;
                 }
+                else
+                {
+                    if (!generateMethod) continue;
+                }
+                list.Add(new(item));
             }
         }
         return list.ToArray();

--- a/src/PrivateProxy.Generator/PrivateProxyGenerator.cs
+++ b/src/PrivateProxy.Generator/PrivateProxyGenerator.cs
@@ -358,7 +358,7 @@ namespace PrivateProxy
                     {
                         code.AppendLine($$"""
     [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
-    public static extern {{targetTypeFullName}} Create{{targetType.Name}}({{parameters}});
+    public static extern {{targetTypeFullName}} Create{{targetType.Name}}FromConstructor({{parameters}});
 
 """);
                     }

--- a/src/PrivateProxy.Generator/Properties/launchSettings.json
+++ b/src/PrivateProxy.Generator/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Profile 1": {
       "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\..\\sandbox\\ConsoleAppNet8\\ConsoleAppNet8.csproj"
+      "targetProject": "../../sandbox/ConsoleAppNet8/ConsoleAppNet8.csproj"
     }
   }
 }

--- a/tests/PrivateProxy.Tests/ChangeKindTest.cs
+++ b/tests/PrivateProxy.Tests/ChangeKindTest.cs
@@ -57,7 +57,7 @@ public partial struct KindTargetProxy { }
         public void All()
         {
             var all = GenerateCode(PrivateProxyGenerateKinds.All);
-            Regex.Count(all, @"\[UnsafeAccessor.+\]").Should().Be(8);
+            Regex.Count(all, @"\[UnsafeAccessor.+\]").Should().Be(9);
         }
 
         [Fact]

--- a/tests/PrivateProxy.Tests/ChangeKindTest.cs
+++ b/tests/PrivateProxy.Tests/ChangeKindTest.cs
@@ -41,6 +41,8 @@ public class KindTarget
     static private int staticField;
     static private int StaticProperty { get; set; }
     static private int StaticMethod() => 3;
+    
+    private KindTarget(int x) { }
 }
 
 [GeneratePrivateProxy(typeof(KindTarget), {{kind}})]
@@ -130,6 +132,13 @@ public partial struct KindTargetProxy { }
             Regex.Count(all, @"\[UnsafeAccessor\(UnsafeAccessorKind.Static.+\]").Should().Be(0);
             Regex.Count(all, @"\[UnsafeAccessor\(UnsafeAccessorKind.(?!Static).+\]").Should().Be(1);
         }
+
+        [Fact]
+        public void ConstructorOnly()
+        {
+            var all = GenerateCode(PrivateProxyGenerateKinds.Constructor);
+            Regex.Count(all, @"\[UnsafeAccessor.+\]").Should().Be(1);
+        } 
 
         [Fact]
         public void Mix()


### PR DESCRIPTION
In accordance with proposal #5, private constructor was supported.


```cs
    [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
    public static extern Foo CreateFooFromConstructor(ParmType, param, ....);
```

NOTE: 
There is probably a risk of name conflict with other private method names.
So I added `...FromConstructor` suffix so the risk is small.
(The only workaround for the conflict is for the user to unspecify UnsafeAccessorKind.Constructor.
